### PR TITLE
version 0.9.7

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask import (Flask, redirect, render_template, request, session, url_for)
 from app import consent, alert, experiment, complete, error
 from .io import write_metadata
 from .utils import gen_code
-__version__ = '0.9.6'
+__version__ = '0.9.7'
 
 ## Define root directory.
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -89,11 +89,11 @@ def index():
 
         ## Update metadata.
         for k, v in info.items(): session[k] = v
-        session['ERROR'] = "1004: Revisited home."
-        write_metadata(session, ['ERROR'], 'a')
+        session['WARNING'] = "Revisited home."
+        write_metadata(session, ['WARNING'], 'a')
 
         ## Redirect participant to error (previous participation).
-        return redirect(url_for('error.error', errornum=1004))
+        return redirect(url_for('consent.consent'))
 
     ## Case 5: first visit, workerId present.
     else:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -92,7 +92,7 @@ def index():
         session['WARNING'] = "Revisited home."
         write_metadata(session, ['WARNING'], 'a')
 
-        ## Redirect participant to error (previous participation).
+        ## Redirect participant to consent form.
         return redirect(url_for('consent.consent'))
 
     ## Case 5: first visit, workerId present.


### PR DESCRIPTION
Small bug fix to address issue #31. Previously, participants were kicked out for revisiting the launch page, which unfairly excluded participants who would open a HIT for later. Now participants only reach the error 1004 (repeat visit) page if they repeat-visit the experiment page itself. 