### PR TITLE
standalone-v0.1-sz

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -93,12 +93,26 @@ def index():
         ## Redirect participant to error (missing workerId).
         return redirect(url_for('input.input'))
 
-    ## Case 5: first visit.
+    ## Case 5: workerId present.
     else:
 
         ## Update metadata.
         for k, v in info.items(): session[k] = v
-        write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
+
+        # Case 5a: repeat visit, preexisting log but no session data.
+        if info['workerId'] in os.listdir(meta_dir):
+
+            ## Add warning to metadata file.
+            session['WARNING'] = "Assigned new subId."
+
+            ## Update metadata.
+            write_metadata(session, ['WARNING', 'workerId','subId','address','browser','platform','version'], 'a')
+
+        ## Case 5b: first visit.
+        else:
+
+            ## Add a warning and print the new metadata to the metadata file.
+            write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
 
         ## Redirect participant to consent form.
         return redirect(url_for('consent.consent'))

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,7 +111,7 @@ def index():
         ## Case 5b: first visit.
         else:
 
-            ## Add a warning and print the new metadata to the metadata file.
+            ## Update metadata.
             write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
 
         ## Redirect participant to consent form.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask import (Flask, redirect, render_template, request, session, url_for)
 from app import input, consent, experiment, complete, error
 from .io import write_metadata
 from .utils import gen_code
-__version__ = '1.0'
+__version__ = '0.1'
 
 ## Define root directory.
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -95,9 +95,10 @@ def index():
             ## Add a warning and print the new metadata to the metadata file.
             session['WARNING'] = "Repeat workerId detected; a new subId was assigned."
             write_metadata(session, ['WARNING', 'workerId','subId','address','browser','platform','version'], 'a')
-        else:
-            write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
 
+        else:
+
+            write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
 
         ## Redirect participant to consent form.
         return redirect(url_for('consent.consent'))

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,13 +67,7 @@ def index():
         ## Redirect participant to error (platform error).
         return redirect(url_for('error.error', errornum=1001))
 
-    ## Case 2: workerId absent.
-    elif not 'workerId' in session and info['workerId'] is None:
-
-        ## Redirect participant to error (missing workerId).
-        return redirect(url_for('input.input'))
-
-    ## Case 3: repeat visit, previously completed experiment.
+    ## Case 2: repeat visit, previously completed experiment.
     elif 'complete' in session:
 
         ## Update metadata.
@@ -83,22 +77,28 @@ def index():
         ## Redirect participant to complete page.
         return redirect(url_for('complete.complete'))
 
-    ## Case 4: workerId present.
+    ## Case 3: repeat visit, preexisting activity.
+    elif 'workerId' in session:
+
+        ## Update metadata.
+        session['WARNING'] = "Revisited home."
+        write_metadata(session, ['WARNING'], 'a')
+
+        ## Redirect participant to consent form.
+        return redirect(url_for('consent.consent'))
+
+    ## Case 4: workerId absent.
+    elif info['workerId'] is None:
+
+        ## Redirect participant to error (missing workerId).
+        return redirect(url_for('input.input'))
+
+    ## Case 5: first visit.
     else:
 
         ## Update metadata.
         for k, v in info.items(): session[k] = v
-
-        # Check to see whether the input ID duplicates an existing worker ID.
-        if info['workerId'] in os.listdir(meta_dir):
-
-            ## Add a warning and print the new metadata to the metadata file.
-            session['WARNING'] = "Repeat workerId detected; a new subId was assigned."
-            write_metadata(session, ['WARNING', 'workerId','subId','address','browser','platform','version'], 'a')
-
-        else:
-
-            write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
+        write_metadata(session, ['workerId','subId','address','browser','platform','version'], 'w')
 
         ## Redirect participant to consent form.
         return redirect(url_for('consent.consent'))

--- a/app/experiment.py
+++ b/app/experiment.py
@@ -13,7 +13,7 @@ def experiment():
     if not 'workerId' in session:
 
         ## Redirect participant to error (missing workerId).
-        return redirect(url_for('error.error', errornum=1000))
+        return redirect(url_for('input.input'))
 
     ## Case 1: previously completed experiment.
     elif 'complete' in session:
@@ -58,25 +58,6 @@ def pass_message():
     ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
     return ('', 200)
 
-@bp.route('/save_partial_data', methods=['POST'])
-def save_partial_data():
-    """Write jsPsych message to metadata."""
-
-    if request.is_json:
-
-        ## Retrieve jsPsych data.
-        JSON = request.get_json()
-
-        ## Save jsPsch data to disk.
-        write_data(session, JSON)
-
-    ## DEV NOTE:
-    ## This function returns the HTTP response status code: 200
-    ## Code 200 signifies the POST request has succeeded.
-    ## For a full list of status codes, see:
-    ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-    return ('', 200)
-
 @bp.route('/save_data', methods = ['POST'])
 def save_data():
     """Save complete jsPsych dataset to disk."""
@@ -86,12 +67,16 @@ def save_data():
         ## Retrieve jsPsych data.
         JSON = request.get_json()
 
+        ## Retrieve status.
+        status = request.args.get('status')
+
         ## Save jsPsch data to disk.
         write_data(session, JSON)
 
     ## Flag experiment as complete.
-    session['complete'] = 'success'
-    write_metadata(session, ['complete'], 'a')
+    if status == "complete":
+        session['complete'] = 'success'
+        write_metadata(session, ['complete'], 'a')
 
     ## DEV NOTE:
     ## This function returns the HTTP response status code: 200

--- a/app/input.py
+++ b/app/input.py
@@ -10,11 +10,19 @@ def input():
 
 @bp.route('/input/', methods=['POST'])
 def input_post():
-    """Process participant response to alert page."""
+    """Process participant response to input page."""
 
+    ## Retrieve participant response.
     id_input = request.form['id-input']  # get the user's id from the form
 
-    if id_input: # check to see if input is present
+    ## Case 1: workerId present.
+    if id_input:
+
+        ## If present, participant is implicitly redirected back to index (home).
         return redirect(url_for('index', workerId=id_input))
+
+    ## Case 2: missing workerId.
     else:
+
+        ## If absent, participant is re-presented the input page.
         return render_template('input.html')

--- a/app/static/js/nivturk-plugins.js
+++ b/app/static/js/nivturk-plugins.js
@@ -14,29 +14,13 @@ function pass_message(msg) {
 
 }
 
-// Write partial data on attempted unload
-function save_partial_data() {
-
-  $.ajax({
-    url: "/save_partial_data",
-    method: 'POST',
-    data: JSON.stringify(jsPsych.data.get().json()),
-    contentType: "application/json; charset=utf-8",
-  }).done(function(data, textStatus, jqXHR) {
-    // do nothing on success
-  }).fail(function(error) {
-    console.log(error);
-  });
-
-}
-
 // Write data on experiment end
-function save_data() {
+function save_data(status) {
 
   var url = "/complete";
 
   $.ajax({
-    url: "/save_data",
+    url: "/save_data?status=" + status,
     method: 'POST',
     data: JSON.stringify(jsPsych.data.get().json()),
     contentType: "application/json; charset=utf-8",

--- a/app/static/js/nivturk-plugins.js
+++ b/app/static/js/nivturk-plugins.js
@@ -17,15 +17,16 @@ function pass_message(msg) {
 // Write data on experiment end
 function save_data(status) {
 
-  var url = "/complete";
-
   $.ajax({
     url: "/save_data?status=" + status,
     method: 'POST',
     data: JSON.stringify(jsPsych.data.get().json()),
     contentType: "application/json; charset=utf-8",
   }).done(function(data, textStatus, jqXHR) {
-    window.location.replace(url);
+    // if complete, redirect to complete page. otherwise, do nothing
+    if (status == "complete") {
+      window.location.replace("/complete");
+    }
   }).fail(function(error) {
     console.log(error);
   });

--- a/app/templates/experiment.html
+++ b/app/templates/experiment.html
@@ -29,7 +29,7 @@
     (e || window.event).returnValue = null;
 
     // save all data collected thus far
-    save_partial_data()
+    save_data("partial");
 
     return null;
   };
@@ -62,7 +62,7 @@
       // jsPsych.data.displayData();
 
       // Save complete dataset to disk.
-      save_data();
+      save_data("complete");
 
 
     }

--- a/app/templates/input.html
+++ b/app/templates/input.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Decision Making Experiment - ID input</title>
-  <link href="/static/css/tacit-css.min.css" rel="stylesheet" type="text/css"></link>
+  <link rel="stylesheet" href="/static/css/tacit-css.min.css"/>
 </head>
 <style>
 
@@ -46,7 +46,7 @@
           <form method="post">
             <p>Please enter your ID:</p>
             <input type="text" class="input-container" name="id-input">
-            <input type="submit" value="Continue">
+            <input type="submit" value="Continue" style="background: #ffb347; color: #fff; border-radius:4px; padding: 5px 15px;">
           </form>
 
         </p>


### PR DESCRIPTION
Requesting review for pull request into standalone branch. Some suggested edits:

**Major edits**
- Reorganized and amended route logic in `index()` to fix Flask errors that were triggered when participants revisited home (index) after a previous visit. 
- Collapsed `/save_data` and `/save_partial_data` routes using a small request trick.

**Minor edits**
- Matched redirect routes between `consent()` and `experiment()` when no workerId present.
- Minor documentation changes to comments in Flask code.
- Minor CSS changes to input page to highlight "Continue" button.
- Set version to **0.1** until further live testing is finished. 

**Unit Testing**
Code was tested with `debug=false`. Tried various permutations of participant visits with and without incognito windows.