### PR TITLE
mturk-issue-#96

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask import (Flask, redirect, render_template, request, session, url_for)
 from app import consent, alert, experiment, complete, error
 from .io import write_metadata
 from .utils import gen_code
-__version__ = '1.2'
+__version__ = '1.2.1'
 
 ## Define root directory.
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -67,16 +67,12 @@ def index():
         assignmentId = request.args.get('assignmentId'),    # MTurk metadata
         hitId        = request.args.get('hitId'),           # MTurk metadata
         subId        = gen_code(24),                        # NivTurk metadata
-        a            = request.args.get('a'),               # TurkPrime metadata
-        tp_a         = request.args.get('tp_a'),            # TurkPrime metadata
-        b            = request.args.get('b'),               # TurkPrime metadata
-        tp_b         = request.args.get('tp_b'),            # TurkPrime metadata
-        c            = request.args.get('c'),               # TurkPrime metadata
-        tp_c         = request.args.get('tp_c'),            # TurkPrime metadata
         address      = request.remote_addr,                 # NivTurk metadata
         browser      = request.user_agent.browser,          # User metadata
         platform     = request.user_agent.platform,         # User metadata
         version      = request.user_agent.version,          # User metadata
+        code_success = cfg['CLOUDRESEARCH'].get('CODE_SUCCESS', gen_code(8).upper()),
+        code_reject  = cfg['CLOUDRESEARCH'].get('CODE_REJECT', gen_code(8).upper()),
     )
 
     ## Case 1: workerId absent form URL.

--- a/app/app.ini
+++ b/app/app.ini
@@ -12,6 +12,16 @@ ALLOW_RESTART = false
 # Accepts true or false
 DEBUG = true
 
+[CLOUDRESEARCH]
+
+# Participant completion code on success
+# Accepts string, or comment out for per-user codes
+CODE_SUCCESS = CR_CODE_GOES_HERE
+
+# Participant completion code on reject
+# Accepts string, or comment out for per-user codes
+CODE_REJECT = qgDFzUQOR7XN
+
 [IO]
 
 # Path to metadata folder [default: ../metadata]

--- a/app/complete.py
+++ b/app/complete.py
@@ -8,13 +8,6 @@ bp = Blueprint('complete', __name__)
 def complete():
     """Present completion screen to participant."""
 
-    ## Access query string.
-    query_info = request.args
-
-    ## Confirm all CloudResearch metadata present.
-    fields = ['workerId','assignmentId','hitId','a','tp_a','b','tp_b','c','tp_c']
-    all_fields = all([f in query_info for f in fields])
-
     ## Error-catching: screen for missing session.
     if not 'workerId' in session:
 

--- a/app/complete.py
+++ b/app/complete.py
@@ -47,15 +47,8 @@ def complete():
         ## Redirect participant to error (unusual activity).
         return redirect(url_for('error.error', errornum=errornum))
 
-    ## Case 4: visit complete page with previous success.
-    elif session['complete'] == 'success' and not all_fields:
-
-        ## Redirect participant with complete metadata.
-        url = "/complete?workerId=%s&assignmentId=%s&hitId=%s&a=%s&tp_a=%s&b=%s&tp_b=%s&c=%s&tp_c=%s" %(session['workerId'], session['assignmentId'], session['hitId'], session['a'], session['tp_a'], session['b'], session['tp_b'], session['c'], session['tp_c'])
-        return redirect(url)
-
-    ## Case 5: all else.
+    ## Case 4: all else.
     else:
 
         ## Redirect participant with completion code.
-        return render_template('complete.html')
+        return render_template('complete.html', completion_code=session['code_success'])

--- a/app/experiment.py
+++ b/app/experiment.py
@@ -39,7 +39,7 @@ def experiment():
         write_metadata(session, ['experiment'], 'a')
 
         ## Present experiment.
-        return render_template('experiment.html', workerId=session['workerId'], assignmentId=session['assignmentId'], hitId=session['hitId'], a=session['a'], tp_a=session['tp_a'], b=session['b'], tp_b=session['tp_b'], c=session['c'], tp_c=session['tp_c'])
+        return render_template('experiment.html', workerId=session['workerId'], assignmentId=session['assignmentId'], hitId=session['hitId'], code_success=session['code_success'], code_reject=session['code_reject'])
 
 @bp.route('/experiment', methods=['POST'])
 def pass_message():

--- a/app/static/js/nivturk-plugins.js
+++ b/app/static/js/nivturk-plugins.js
@@ -31,10 +31,10 @@ function incomplete_save() {
 }
 
 // Successful completion of experiment: redirect with completion code.
-function redirect_success(workerId, assignmentId, hitId, a, tp_a, b, tp_b, c, tp_c) {
+function redirect_success(workerId, assignmentId, hitId, code_success) {
 
   // Concatenate metadata into complete URL (returned on success).
-  var url = "/complete?workerId=" + workerId + "&assignmentId=" + assignmentId + "&hitId=" + hitId + "&a=" + a + "&tp_a=" + tp_a + "&b=" + b + "&tp_b=" + tp_b + "&c=" + c + "&tp_c=" + tp_c;
+  var url = "/complete?completion_code=" + code_success;
 
   $.ajax({
     url: "/redirect_success",

--- a/app/templates/complete.html
+++ b/app/templates/complete.html
@@ -4,23 +4,10 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<title>Decision Making Experiment - Completed</title>
-	<link rel="stylesheet" href="/static/css/tacit-css.min.css"/>
+	<link rel="stylesheet" href="../static/css/tacit-css.min.css"/>
 </head>
 <body>
-	<div id="container-not-an-ad" class="media">
-		<div class="media-body">
-			<center><h1>Thank you for completing our experiment!</h1></center>
-
-		</div>
-		<center><iframe width='80%' height='400' id="cr_secretcode"></iframe></iframe></center>
-	</div>
+	<center><h1>Thank you for completing our experiment!</h1></center>
+	<center><h3>Your completion code is <font style="color: #fa9200">{{completion_code}}</font></h3></center>
 </body>
-<script>
-    function createIFrame() {
-        var ref = encodeURIComponent(document.location.search);
-        var ifrm = document.getElementById("cr_secretcode");
-        ifrm.setAttribute("src", "https://app.cloudresearch.com/TakeLaunchedSurvey/DynamicKey/?referrer=" + ref);
-    }
-    createIFrame();
-</script>
 </html>

--- a/app/templates/experiment.html
+++ b/app/templates/experiment.html
@@ -67,7 +67,7 @@
       } else {
 
         // Save complete dataset to disk.
-        redirect_success("{{workerId}}", "{{assignmentId}}", "{{hitId}}",  "{{a}}", "{{tp_a}}", "{{b}}", "{{tp_b}}", "{{c}}", "{{tp_c}}");
+        redirect_success("{{workerId}}", "{{assignmentId}}", "{{hitId}}", "{{code_success}}");
 
       }
 


### PR DESCRIPTION
To address #96. In short, Cloudresearch is no longer using dynamic completion codes. Instead, they have switched to a static completion code system like Prolific. 

To address this problem, I've made the MTurk branch more similar to the Prolific branch. The major changes were:
- The configuration (`app.ini`) file now accepts real and decoy codes (the latter is currently non-operational, as rejected participants are currently sent to the 1005 error).
- The completion page has been updated to return the completion code specified in the configuration file. 

I've tested this branch for a recent experiment with @seanmallan, and it worked fine. Given that the MTurk branch is used less often than the Prolific branch, I am bypassing code review. If problems creep up, feel free to contact me (@szorowi1). 