### PR TITLE
Added ability to print (and save as pdf)

### DIFF
--- a/app/static/css/tacit-css.min.css
+++ b/app/static/css/tacit-css.min.css
@@ -14,6 +14,8 @@ html {
   height: 100%
 }
 body {
+  max-width: 1200px;
+  margin: auto;
   background: #fff;
   color: #1a1919;
   padding: 36px

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -166,7 +166,6 @@ The consent.html displays the text of an IRB-approved consent form.
     </form>
   </center>
 
-</div>
 </body>
 <style>
 .recontact {

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -10,6 +10,8 @@ The consent.html displays the text of an IRB-approved consent form.
   <link rel="stylesheet" href="/static/css/tacit-css.min.css"/>
 </head>
 <body>
+  <!-- Set padding for white space -->
+  <div style="padding:30px 100px 80px; line-height: 1.6em">
 
   <!-- Study headers -->
   <h1>CONSENT FORM</h1>
@@ -124,6 +126,16 @@ The consent.html displays the text of an IRB-approved consent form.
       <li>Email: irb@princeton.edu</li>
     </ul>
   </p>
+  <p> If you wish to save a copy of the consent form, click the Print button to print and/or save as PDF: 
+    <br>
+    <button onclick="printFunction()">Print or Save Consent Form</button>
+    <script>
+          function printFunction() { 
+            window.print(); 
+          }
+    </script>
+    <br>
+  </p>
 
   <hr>
 
@@ -156,6 +168,7 @@ The consent.html displays the text of an IRB-approved consent form.
     </form>
   </center>
 
+</div>
 </body>
 <style>
 .recontact {

--- a/app/templates/consent.html
+++ b/app/templates/consent.html
@@ -10,8 +10,6 @@ The consent.html displays the text of an IRB-approved consent form.
   <link rel="stylesheet" href="/static/css/tacit-css.min.css"/>
 </head>
 <body>
-  <!-- Set padding for white space -->
-  <div style="padding:30px 100px 80px; line-height: 1.6em">
 
   <!-- Study headers -->
   <h1>CONSENT FORM</h1>


### PR DESCRIPTION
As a simple solution for now, have added the ability to print the consent form (which also allows participant to save as PDF). This way, participants can always have the latest up-to-date version printed/saved; and by-passes the need for experimenters to upload a PDF.
Also added in slight padding to page.