### PR TITLE
issue #122 (prolific branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.2.5 (2023-04-09)
+
+Authors: Sam Zorowitz ([#123](https://github.com/nivlab/nivturk/pull/123))
+
+- Remove deprecated `request.user_agent` calls.
+- Return entire `request.user_agent` string.
+- Expand list of screened devices (e.g., mobile, tablets, game consoles).
+
 ## v1.2.4 (2023-02-28)
 
 Authors: Yongjing Ren, Sam Zorowitz ([#120](https://github.com/nivlab/nivturk/pull/120))

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask import (Flask, redirect, render_template, request, session, url_for)
 from app import consent, alert, experiment, complete, error
 from .io import write_metadata
 from .utils import gen_code
-__version__ = '1.2.4'
+__version__ = '1.2.5'
 
 ## Define root directory.
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -68,9 +68,7 @@ def index():
         hitId        = request.args.get('STUDY_ID'),        # Prolific metadata
         subId        = gen_code(24),                        # NivTurk metadata
         address      = request.remote_addr,                 # NivTurk metadata
-        browser      = request.user_agent.browser,          # User metadata
-        platform     = request.user_agent.platform,         # User metadata
-        version      = request.user_agent.version,          # User metadata
+        user_agent   = request.user_agent.string,           # User metadata
         code_success = cfg['PROLIFIC'].get('CODE_SUCCESS', gen_code(8).upper()),
         code_reject  = cfg['PROLIFIC'].get('CODE_REJECT', gen_code(8).upper()),
     )
@@ -81,8 +79,8 @@ def index():
         ## Redirect participant to error (missing workerId).
         return redirect(url_for('error.error', errornum=1000))
 
-    ## Case 2: mobile / tablet user.
-    elif info['platform'] in ['android','iphone','ipad','wii']:
+    ## Case 2: mobile / tablet / game console user.
+    elif any([device in info['user_agent'].lower() for device in ['mobile','android','iphone','ipad','kindle','nintendo','playstation','xbox']]):
 
         ## Redirect participant to error (platform error).
         return redirect(url_for('error.error', errornum=1001))
@@ -150,7 +148,7 @@ def index():
 
         ## Update metadata.
         for k, v in info.items(): session[k] = v
-        write_metadata(session, ['workerId','hitId','assignmentId','subId','address','browser','platform','version'], 'w')
+        write_metadata(session, ['workerId','hitId','assignmentId','subId','address','user_agent'], 'w')
 
         ## Redirect participant to consent form.
         return redirect(url_for('consent.consent'))


### PR DESCRIPTION
## Purpose
To close #122 

## Explanation

@danielbrianbennett, @YJ-Ren: The purpose of this PR is to address #122. Specifically, as of Werkzeug 2.0 / Flask 2.1, the old calls to `request.user_agent` have been deprecated such that querying a user's browser or platform returns `None`. As such, I am proposing NivTurk now simply return the entire user agent string (i.e., `request.user_agent.string`). When NivTurk users need to look up participants' device info, they can pass that string to external resources such as [browser-info](http://www.browser-info.net/useragent) or [ua-parser](https://github.com/ua-parser/uap-python).